### PR TITLE
Add function to compute and remove monopole & dipole from map

### DIFF
--- a/pspy/so_map.py
+++ b/pspy/so_map.py
@@ -763,6 +763,7 @@ def subtract_mono_dipole(emap, mask=None, healpix=True, bunch=24, return_values=
     return_values: bool
       Return mono/dipole values with the subtracted map (default: False)
     """
+    map_cleaned = emap.copy()
     if healpix:
         map_masked = hp.ma(emap)
         if mask is not None:
@@ -775,10 +776,10 @@ def subtract_mono_dipole(emap, mask=None, healpix=True, bunch=24, return_values=
             ipix = np.arange(ibunch * bunchsize, (ibunch + 1) * bunchsize)
             ipix = ipix[(np.isfinite(emap.flat[ipix]))]
             x, y, z = hp.pix2vec(nside, ipix, False)
-            emap.flat[ipix] -= dipole[0] * x
-            emap.flat[ipix] -= dipole[1] * y
-            emap.flat[ipix] -= dipole[2] * z
-            emap.flat[ipix] -= mono
+            map_cleaned.flat[ipix] -= dipole[0] * x
+            map_cleaned.flat[ipix] -= dipole[1] * y
+            map_cleaned.flat[ipix] -= dipole[2] * z
+            map_cleaned.flat[ipix] -= mono
 
     else:
         if mask is not None:
@@ -837,11 +838,11 @@ def subtract_mono_dipole(emap, mask=None, healpix=True, bunch=24, return_values=
                 ipix = ipix[mask.flat[ipix] > 0]
 
             x, y, z = _get_xyz(theta=np.pi / 2 - dec[ipix], phi=ra[ipix])
-            emap.flat[ipix] -= dipole[0] * x
-            emap.flat[ipix] -= dipole[1] * y
-            emap.flat[ipix] -= dipole[2] * z
-            emap.flat[ipix] -= mono
+            map_cleaned.flat[ipix] -= dipole[0] * x
+            map_cleaned.flat[ipix] -= dipole[1] * y
+            map_cleaned.flat[ipix] -= dipole[2] * z
+            map_cleaned.flat[ipix] -= mono
 
     if return_values:
-        return emap, mono, dipole
-    return emap
+        return map_cleaned, mono, dipole
+    return map_cleaned

--- a/pspy/tests/test_so_map.py
+++ b/pspy/tests/test_so_map.py
@@ -76,7 +76,7 @@ class SOMapTests(unittest.TestCase):
         # Test so_map method
         m.ncomp = 3
         m.data = np.tile(m.data, (3, 1))
-        m.subtract_mono_dipole(mask)
+        m.subtract_mono_dipole(mask=(mask, mask))
         np.testing.assert_almost_equal(m.data, 0.0)
 
     def test_subtract_mono_dipole_car(self):
@@ -104,7 +104,7 @@ class SOMapTests(unittest.TestCase):
         # Test so_map method
         m.ncomp = 3
         m.data = np.tile(m.data, (3, 1, 1))
-        m.subtract_mono_dipole(mask)
+        m.subtract_mono_dipole(mask=(mask, mask))
         np.testing.assert_almost_equal(m.data, 0.0)
 
 

--- a/pspy/tests/test_so_map.py
+++ b/pspy/tests/test_so_map.py
@@ -1,0 +1,112 @@
+"""Tests for `pspy.so_map` object."""
+
+import os
+import unittest
+
+import healpy as hp
+import numpy as np
+from pspy import so_map
+
+TEST_DATA_PREFIX = os.path.join(os.path.dirname(__file__), "data")
+
+
+def test_maps_equality(so_map1, so_map2):
+    assert so_map1.pixel == so_map2.pixel
+    assert so_map1.nside == so_map2.nside
+    assert so_map1.ncomp == so_map2.ncomp
+    # assert so_map1.geometry[0] == so_map2.geometry[0]
+    assert so_map1.coordinate == so_map2.coordinate
+    assert np.allclose(so_map1.data, so_map2.data, rtol=0, atol=1e-4)
+
+
+class SOMapTests(unittest.TestCase):
+    def test_box(self):
+        ra0, ra1, dec0, dec1 = -1, 2, -3, 4
+        box = so_map.get_box(ra0, ra1, dec0, dec1)
+        box = np.rad2deg(box)
+        self.assertEqual(box[0, 0], dec0)
+        self.assertEqual(box[0, 1], ra1)
+        self.assertEqual(box[1, 0], dec1)
+        self.assertEqual(box[1, 1], ra0)
+
+    def test_copy(self):
+        ncomp, res = 3, 1
+        ra0, ra1, dec0, dec1 = -1, 2, -3, 4
+        so_map1 = so_map.car_template(ncomp, ra0, ra1, dec0, dec1, res)
+        so_map2 = so_map1.copy()
+        test_maps_equality(so_map1, so_map2)
+
+    # def test_car_synfast(self):
+    #     # Fix seed
+    #     np.random.seed(666)
+    #     ra0, ra1, dec0, dec1 = -5, 5, -5, 5
+    #     res = 1
+    #     ncomp = 3
+    #     so_map1 = so_map.car_template(ncomp, ra0, ra1, dec0, dec1, res)
+    #     so_map2 = so_map.read_map(os.path.join(TEST_DATA_PREFIX, "map_car.fits"))
+    #     test_maps_equality(so_map1.synfast(os.path.join(TEST_DATA_PREFIX, "cl_camb.dat")), so_map2)
+
+    # def test_healpix_synfast(self):
+    #     # Fix seed
+    #     np.random.seed(666)
+    #     nside = 256
+    #     ncomp = 3
+    #     so_map1 = so_map.healpix_template(ncomp, nside)
+    #     so_map2 = so_map.read_map(os.path.join(TEST_DATA_PREFIX, "map_healpix.fits"))
+    #     test_maps_equality(so_map1.synfast(os.path.join(TEST_DATA_PREFIX, "cl_camb.dat")), so_map2)
+
+    def test_subtract_mono_dipole_healpix(self):
+        monopole = 0.5
+        dipole = np.array([0.0, 1.0, 0.0])
+        nside = 32
+        m = so_map.healpix_template(ncomp=1, nside=nside)
+        mask = m.copy()
+        m.data = np.full_like(m.data, monopole)
+        for ipix in range(hp.nside2npix(nside)):
+            vec = hp.pix2vec(nside, ipix)
+            m.data[ipix] += np.sum(vec * dipole)
+            mask.data[ipix] = 1 if vec[0] < 0.5 else 0
+
+        # Test raw function
+        results = so_map.subtract_mono_dipole(m.data, mask.data, return_values=True)
+        np.testing.assert_almost_equal(results[0], 0.0)
+        self.assertAlmostEqual(results[1], monopole)
+        np.testing.assert_almost_equal(results[2], dipole)
+
+        # Test so_map method
+        m.ncomp = 3
+        m.data = np.tile(m.data, (3, 1))
+        m.subtract_mono_dipole(mask)
+        np.testing.assert_almost_equal(m.data, 0.0)
+
+    def test_subtract_mono_dipole_car(self):
+        monopole = 0.5
+        dipole = np.array([0.0, 1.0, 0.0])
+        m = so_map.car_template(ncomp=1, res=10, ra0=-180, ra1=180, dec0=-90, dec1=90)
+        mask = m.copy()
+        m.data = np.full_like(m.data, monopole)
+
+        dec, ra = m.data.posmap()
+        theta = np.pi / 2 - dec
+        x = np.sin(theta) * np.cos(ra)
+        y = np.sin(theta) * np.sin(ra)
+        z = np.cos(theta)
+        mask.data = np.where(x < 0.5, 1, 0)
+
+        m.data += np.sum(np.array([x, y, z]) * dipole[:, None, None], axis=0)
+
+        # Test raw function
+        results = so_map.subtract_mono_dipole(m.data, mask.data, healpix=False, return_values=True)
+        np.testing.assert_almost_equal(results[0], 0.0)
+        self.assertAlmostEqual(results[1], monopole)
+        np.testing.assert_almost_equal(results[2], dipole)
+
+        # Test so_map method
+        m.ncomp = 3
+        m.data = np.tile(m.data, (3, 1, 1))
+        m.subtract_mono_dipole(mask)
+        np.testing.assert_almost_equal(m.data, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Removing monopole and dipole works for both HEALPIX and CAR pixellisation and all the job is done
within the specialized `subtract_mono_dipole` function. We also create a `so_map` method in order to
remove mono/dipole within a `so_map`.

Masking the maps can be done in several ways :

1. Both maps and masks have the number of components (I, Q, U). Then each map component is masked with the corresponding mask component
2. Maps have more component than mask. For instance, the maps are I, Q, U and only component is provided for the mask. Then the unique mask component is used for every maps.

Any other combination will raise an error.