### PR TITLE
Fix numpy version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install via pip
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy pytest pytest-cov
+        python -m pip install numpy==1.22.4 pytest pytest-cov
         python -m pip install -e .
 
     - name: Install extra dependencies (camb)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
           CIBW_BEFORE_BUILD: "python -m pip install numpy==1.22.4"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: "cp3*-*x86_64"
-          CIBW_SKIP: "cp3{5,6}-*"
+          CIBW_SKIP: "cp3{5,6,7}-*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
-          CIBW_BEFORE_BUILD: "python -m pip install numpy"
+          CIBW_BEFORE_BUILD: "python -m pip install numpy==1.22.4"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: "cp3*-*x86_64"
           CIBW_SKIP: "cp3{5,6}-*"


### PR DESCRIPTION
Use a slightly outdated version of numpy to make the wheels compatible with NERSC current numpy version.