### PR TITLE
Feature namaster tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,5 +57,5 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install -y libcfitsio-dev
-        pip install pymaster
+        python -m pip install pymaster
         python -m unittest pspy/tests/test_pspy_namaster.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,3 +52,10 @@ jobs:
       run: |
         pip install jupyter
         jupyter nbconvert --to notebook --execute notebooks/tutorial_io.ipynb
+
+    - name: Comparing pspy to NaMaster
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get install -y libcfitsio-dev
+        pip install pymaster
+        python -m unittest pspy/tests/test_pspy_namaster.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,12 +50,12 @@ jobs:
     - name: Test notebooks (Only on Linux for saving time)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        pip install jupyter
+        python -m pip install jupyter
         jupyter nbconvert --to notebook --execute notebooks/tutorial_io.ipynb
 
     - name: Comparing pspy to NaMaster
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install -y libcfitsio-dev
+        sudo apt-get install -y libcfitsio-dev libfftw3-dev
         python -m pip install pymaster
         python -m unittest pspy/tests/test_pspy_namaster.py

--- a/pspy/tests/test_pspy_namaster.py
+++ b/pspy/tests/test_pspy_namaster.py
@@ -1,10 +1,12 @@
 """Tests pspy versus namaster."""
 import os
 import tempfile
+import time
 import unittest
 
 import healpy as hp
 import numpy as np
+import pspy
 from pspy import pspy_utils, so_map, so_mcm, so_spectra, so_window, sph_tools
 
 
@@ -115,11 +117,19 @@ def run_namaster():
 
 class SOPspyNamasterTests(unittest.TestCase):
     def setUp(self):
+        print(f"pspy current version : {pspy.__version__}")
+        # This sould be fixed see https://github.com/LSSTDESC/NaMaster/issues/172
+        # print(f"namaster current version : {nmt.__version__}")
         pass
 
     def test_pspy_namaster(self):
+        t0 = time.time()
         lb_pspy, Clb_pspy = run_pspy()
+        print(f"pspy runs in {time.time() - t0:.2f} seconds")
+
+        t0 = time.time()
         lb_nmt, Clb_nmt = run_namaster()
+        print(f"namaster runs in {time.time() - t0:.2f} seconds")
 
         decimal = 12
         for spec in spectra:


### PR DESCRIPTION
This PR provides a minimal test to compare `pspy` to `NaMaster` (spectra computation so far). It installs `NaMaster` and its dependencies within the Github actions.

It's only done on linux machines.